### PR TITLE
[lua-monitoring] Send ARP table information #3

### DIFF
--- a/netjson-monitoring.lua
+++ b/netjson-monitoring.lua
@@ -25,6 +25,69 @@ function split(str, pat)
    return t
 end
 
+-- parse /proc/net/arp
+function parse_arp()
+   arp_info = {}
+   for line in io.lines('/proc/net/arp') do
+      if line:sub(1, 10) ~= 'IP address' then
+         ip, hw, flags, mac, mask, dev = line:match("(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)")
+         table.insert(arp_info, {
+            ip_address = ip,
+            mac_address = mac,
+            interface = dev,
+	    state = ''
+            -- type = hw,
+            -- flags = flags,
+            -- mask = mask
+         })
+      end
+   end
+   return arp_info
+end
+
+function get_ip_neigh_json()
+   arp_info = {}
+   output = io.popen('ip -json neigh'):read()
+   if output ~= nil then
+      json_output = cjson.decode(output)
+      for _, arp_entry in pairs(json_output) do
+         table.insert(arp_info, {
+            ip_address = arp_entry["dst"],
+            mac_address = arp_entry["lladdr"],
+            interface = arp_entry["dev"],
+            state = arp_entry["state"][1]
+         })
+      end
+   end
+   return arp_info
+end
+
+function get_ip_neigh()
+   arp_info = {}
+   output = io.popen('ip neigh')
+   for line in output:lines() do
+      ip, dev, mac, state = line:match("(%S+)%s+dev%s+(%S+)%s+lladdr%s+(%S+).*%s(%S+)")
+      table.insert(arp_info, {
+         ip_address = ip,
+         mac_address = mac,
+         interface = dev,
+         state = state
+      })
+   end
+   return arp_info
+end
+
+function get_arp_table()
+   arp_table = get_ip_neigh_json()
+   if next(arp_table) == nil then
+      arp_table = get_ip_neigh()
+   end
+   if next(arp_table) == nil then
+      arp_table = parse_arp()
+   end
+   return arp_table
+end
+
 -- takes ubus wireless.status clients output and converts it to NetJSON
 function netjson_clients(clients)
     local data = {}
@@ -69,7 +132,8 @@ netjson = {
         load = load_average,
         memory = system_info.memory,
         swap = system_info.swap
-    }
+    },
+    arp_table = get_arp_table()
 }
 
 -- collect device data
@@ -84,25 +148,27 @@ for radio_name, radio in pairs(wireless_status) do
         name = interface.ifname
         if name then
             clients = ubus:call('hostapd.'..name, 'get_clients', {})
-            iwinfo = ubus:call('iwinfo', 'info', {device = name})
-            netjson_interface = {
-                name = name,
-                statistics = network_status[name].statistics,
-                wireless = {
-                    ssid = iwinfo.ssid,
-                    mode = iwinfo_modes[iwinfo.mode] or iwinfo.mode,
-                    channel = iwinfo.channel,
-                    frequency = iwinfo.frequency,
-                    tx_power = iwinfo.txpower,
-                    signal = iwinfo.signal,
-                    noise = iwinfo.noise,
-                    country = iwinfo.country
+            if clients ~= nil then
+                iwinfo = ubus:call('iwinfo', 'info', {device = name})
+                netjson_interface = {
+                    name = name,
+                    statistics = network_status[name].statistics,
+                    wireless = {
+                        ssid = iwinfo.ssid,
+                        mode = iwinfo_modes[iwinfo.mode] or iwinfo.mode,
+                        channel = iwinfo.channel,
+                        frequency = iwinfo.frequency,
+                        tx_power = iwinfo.txpower,
+                        signal = iwinfo.signal,
+                        noise = iwinfo.noise,
+                        country = iwinfo.country
+                    }
                 }
-            }
-            if next(clients.clients) ~= nil then
-              netjson_interface.wireless.clients = netjson_clients(clients.clients)
+                if next(clients.clients) ~= nil then
+                  netjson_interface.wireless.clients = netjson_clients(clients.clients)
+                end
+                table.insert(interfaces, netjson_interface)
             end
-            table.insert(interfaces, netjson_interface)
         end
     end
 end


### PR DESCRIPTION
It will try to get the ARP information in the following order, falling back
to the next option if not available:
    
* ip -json neigh
* ip neigh
* cat /proc/net/arp
    
Also fixed issue when clients variable is null (In my case both wlan0 and wlan0-1 interfaces existed but hostapd only ran in wlan0-1).
    
Closes #3
