### PR TITLE
[minor/chores] Correct disk usage data units

### DIFF
--- a/netjson-monitoring.lua
+++ b/netjson-monitoring.lua
@@ -166,11 +166,12 @@ function parse_disk_usage()
             filesystem, size, used, available, percent, location = line:match('(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)')
             if filesystem ~= 'tmpfs' and not string.match(filesystem, 'overlayfs') then
                 percent = percent:gsub('%W', '')
+                -- available, size and used are in KiB
                 table.insert(disk_usage_info, {
                     filesystem = filesystem,
-                    available_bytes = tonumber(available),
-                    size_bytes = tonumber(size),
-                    used_bytes = tonumber(used),
+                    available_bytes = tonumber(available)*1024,
+                    size_bytes = tonumber(size)*1024,
+                    used_bytes = tonumber(used)*1024,
                     used_percent = tonumber(percent),
                     mount_point = location,
                 })


### PR DESCRIPTION
Refer to https://github.com/openwisp/openwisp-monitoring/pull/116#pullrequestreview-425679403
I have added a comment which should be self explanatory and I don't think there should be any style difference with `*` operator not having space around it ( as I observed in the rest of the code ) but in case I need to change it please mention so.